### PR TITLE
Replace hardcoded Firebase credentials with environment variables

### DIFF
--- a/090725leirisonda0710-RESTORE.md
+++ b/090725leirisonda0710-RESTORE.md
@@ -29,7 +29,7 @@
 ### **Firebase:**
 
 - **Project ID:** leirisonda-16f8b
-- **API Key:** AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE
+- **API Key:** [REDACTED - CHECK ENVIRONMENT VARIABLES]
 - **Status:** ✅ Ativo
 
 ### **GitHub:**

--- a/090725leirisonda0710.json
+++ b/090725leirisonda0710.json
@@ -25,12 +25,12 @@
   },
   "firebase_config": {
     "project_id": "leirisonda-16f8b",
-    "api_key": "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
+    "api_key": "[REDACTED - USE ENVIRONMENT VARIABLES]",
     "auth_domain": "leirisonda-16f8b.firebaseapp.com",
     "storage_bucket": "leirisonda-16f8b.firebasestorage.app",
-    "messaging_sender_id": "540456875574",
-    "app_id": "1:540456875574:web:8a8fd4870cb4c943a40a97",
-    "measurement_id": "G-R9W43EHH2C",
+    "messaging_sender_id": "[REDACTED - USE ENVIRONMENT VARIABLES]",
+    "app_id": "[REDACTED - USE ENVIRONMENT VARIABLES]",
+    "measurement_id": "[REDACTED - USE ENVIRONMENT VARIABLES]",
     "status": "✅ Ativo e funcional"
   },
   "github_config": {

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -14,14 +14,14 @@ No painel do Netlify (Site Settings > Environment Variables), adicione as seguin
 #### Projeto Principal (Leiria)
 
 ```
-VITE_FIREBASE_API_KEY=AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw
-VITE_FIREBASE_AUTH_DOMAIN=leiria-1cfc9.firebaseapp.com
-VITE_FIREBASE_DATABASE_URL=https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app
-VITE_FIREBASE_PROJECT_ID=leiria-1cfc9
-VITE_FIREBASE_STORAGE_BUCKET=leiria-1cfc9.firebasestorage.app
-VITE_FIREBASE_MESSAGING_SENDER_ID=632599887141
-VITE_FIREBASE_APP_ID=1:632599887141:web:1290b471d41fc3ad64eecc
-VITE_FIREBASE_MEASUREMENT_ID=G-Q2QWQVH60L
+VITE_FIREBASE_API_KEY=your_firebase_api_key_here
+VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+VITE_FIREBASE_DATABASE_URL=https://your-project-default-rtdb.region.firebasedatabase.app
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 ```
 
 #### Projeto Legacy (Leirisonda) - Opcional

--- a/NETLIFY_SETUP.md
+++ b/NETLIFY_SETUP.md
@@ -27,13 +27,13 @@ VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 #### Projeto Legacy (Leirisonda) - Opcional
 
 ```
-VITE_LEIRISONDA_FIREBASE_API_KEY=AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE
-VITE_LEIRISONDA_FIREBASE_AUTH_DOMAIN=leirisonda-16f8b.firebaseapp.com
-VITE_LEIRISONDA_FIREBASE_DATABASE_URL=https://leirisonda-16f8b-default-rtdb.europe-west1.firebasedatabase.app
-VITE_LEIRISONDA_FIREBASE_PROJECT_ID=leirisonda-16f8b
-VITE_LEIRISONDA_FIREBASE_STORAGE_BUCKET=leirisonda-16f8b.firebasestorage.app
-VITE_LEIRISONDA_FIREBASE_MESSAGING_SENDER_ID=1067024677476
-VITE_LEIRISONDA_FIREBASE_APP_ID=1:1067024677476:web:a5e5e30ed4b5a64b123456
+VITE_LEIRISONDA_FIREBASE_API_KEY=your_legacy_firebase_api_key_here
+VITE_LEIRISONDA_FIREBASE_AUTH_DOMAIN=your-legacy-project.firebaseapp.com
+VITE_LEIRISONDA_FIREBASE_DATABASE_URL=https://your-legacy-project-default-rtdb.region.firebasedatabase.app
+VITE_LEIRISONDA_FIREBASE_PROJECT_ID=your-legacy-project-id
+VITE_LEIRISONDA_FIREBASE_STORAGE_BUCKET=your-legacy-project.firebasestorage.app
+VITE_LEIRISONDA_FIREBASE_MESSAGING_SENDER_ID=your_legacy_messaging_sender_id
+VITE_LEIRISONDA_FIREBASE_APP_ID=your_legacy_app_id
 ```
 
 #### Configuração de Projeto

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,47 @@
 [build.environment]
   NODE_VERSION = "20"
   NPM_FLAGS = "--legacy-peer-deps"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/manifest.json"
+  [headers.values]
+    Content-Type = "application/manifest+json"
+    Cache-Control = "public, max-age=86400"
+
+[[headers]]
+  for = "/sw.js"
+  [headers.values]
+    Content-Type = "application/javascript"
+    Service-Worker-Allowed = "/"
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/firebase-messaging-sw.js"
+  [headers.values]
+    Content-Type = "application/javascript"
+    Service-Worker-Allowed = "/"
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/api/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,9 @@
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
 
 /manifest.json
   Content-Type: application/manifest+json

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,16 +1,16 @@
 # PWA and service worker files
-/manifest.json /manifest.json 200
-/sw.js /sw.js 200
-/firebase-messaging-sw.js /firebase-messaging-sw.js 200
+/manifest.json    /manifest.json    200
+/sw.js    /sw.js    200
+/firebase-messaging-sw.js    /firebase-messaging-sw.js    200
 
 # Static assets
-/icon.svg /icon.svg 200
-/robots.txt /robots.txt 200
-/debug-chrome.js /debug-chrome.js 200
-/emergency-recovery.js /emergency-recovery.js 200
+/icon.svg    /icon.svg    200
+/robots.txt    /robots.txt    200
+/debug-chrome.js    /debug-chrome.js    200
+/emergency-recovery.js    /emergency-recovery.js    200
 
 # API routes (if needed)
-/api/* /api/:splat 200
+/api/*    /api/:splat    200
 
 # SPA fallback (must be last)
-/* /index.html 200
+/*    /index.html    200

--- a/src/components/AdvancedSettings.tsx
+++ b/src/components/AdvancedSettings.tsx
@@ -86,15 +86,9 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
     });
 
     try {
-      // Firebase is always configured with fixed settings
-      const config = {
-        apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-        authDomain: "leirisonda-16f8b.firebaseapp.com",
-        projectId: "leirisonda-16f8b",
-        storageBucket: "leirisonda-16f8b.firebasestorage.app",
-        messagingSenderId: "540456875574",
-        appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-      };
+      // Use environment variables for Firebase config
+      const { getLegacyFirebaseConfig } = await import("../config/firebaseEnv");
+      const config = getLegacyFirebaseConfig();
       const tests = [];
 
       // Test 1: Configuration validation

--- a/src/components/FirebaseConfig.tsx
+++ b/src/components/FirebaseConfig.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Cloud, Save, AlertCircle, CheckCircle, RefreshCw } from "lucide-react";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
 interface FirebaseConfigProps {
   onConfigured: () => void;

--- a/src/components/FirebaseConfig.tsx
+++ b/src/components/FirebaseConfig.tsx
@@ -114,17 +114,7 @@ export const FirebaseConfig: React.FC<FirebaseConfigProps> = ({
   };
 
   const handleReset = () => {
-    const defaultConfig = {
-      apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-      authDomain: "leiria-1cfc9.firebaseapp.com",
-      databaseURL:
-        "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-      projectId: "leiria-1cfc9",
-      storageBucket: "leiria-1cfc9.firebasestorage.app",
-      messagingSenderId: "632599887141",
-      appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-      measurementId: "G-Q2QWQVH60L",
-    };
+    const defaultConfig = getFirebaseConfig();
 
     setConfig(defaultConfig);
     // Salvar a nova configuração no localStorage

--- a/src/components/FirebaseConfig.tsx
+++ b/src/components/FirebaseConfig.tsx
@@ -58,18 +58,8 @@ export const FirebaseConfig: React.FC<FirebaseConfigProps> = ({
         );
       }
 
-      // If no stored config, use the provided default config
-      const defaultConfig = {
-        apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-        authDomain: "leiria-1cfc9.firebaseapp.com",
-        databaseURL:
-          "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-        projectId: "leiria-1cfc9",
-        storageBucket: "leiria-1cfc9.firebasestorage.app",
-        messagingSenderId: "632599887141",
-        appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-        measurementId: "G-Q2QWQVH60L",
-      };
+      // If no stored config, use the environment variables config
+      const defaultConfig = getFirebaseConfig();
 
       setConfig(defaultConfig);
       setIsConfigLoaded(true);

--- a/src/firebase/iosFirebaseFix.ts
+++ b/src/firebase/iosFirebaseFix.ts
@@ -82,15 +82,8 @@ export class IOSFirebaseFix {
       } = await import("firebase/firestore");
       const { getAuth, connectAuthEmulator } = await import("firebase/auth");
 
-      const config = {
-        apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-        authDomain: "leirisonda-16f8b.firebaseapp.com",
-        projectId: "leirisonda-16f8b",
-        storageBucket: "leirisonda-16f8b.firebasestorage.app",
-        messagingSenderId: "540456875574",
-        appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-        measurementId: "G-R9W43EHH2C",
-      };
+      const { getLegacyFirebaseConfig } = await import("../config/firebaseEnv");
+      const config = getLegacyFirebaseConfig();
 
       // Create fresh app with unique name
       const app = initializeApp(config, `ios-fix-${Date.now()}`);

--- a/src/firebase/mobileConfig.ts
+++ b/src/firebase/mobileConfig.ts
@@ -6,19 +6,10 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
-// Configuração Firebase limpa
-const firebaseConfig = {
-  apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-  authDomain: "leiria-1cfc9.firebaseapp.com",
-  databaseURL:
-    "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-  projectId: "leiria-1cfc9",
-  storageBucket: "leiria-1cfc9.firebasestorage.app",
-  messagingSenderId: "632599887141",
-  appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-  measurementId: "G-Q2QWQVH60L",
-};
+// Configuração Firebase usando environment variables
+const firebaseConfig = getFirebaseConfig();
 
 let app: any = null;
 let db: any = null;

--- a/src/firebase/noGetImmediateConfig.ts
+++ b/src/firebase/noGetImmediateConfig.ts
@@ -4,18 +4,9 @@
  */
 
 import { initializeApp, getApps, FirebaseApp } from "firebase/app";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
-const firebaseConfig = {
-  apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-  authDomain: "leiria-1cfc9.firebaseapp.com",
-  databaseURL:
-    "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-  projectId: "leiria-1cfc9",
-  storageBucket: "leiria-1cfc9.firebasestorage.app",
-  messagingSenderId: "632599887141",
-  appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-  measurementId: "G-Q2QWQVH60L",
-};
+const firebaseConfig = getFirebaseConfig();
 
 export class NoGetImmediateFirebase {
   private static app: FirebaseApp | null = null;

--- a/src/firebase/simpleConfig.ts
+++ b/src/firebase/simpleConfig.ts
@@ -2,18 +2,9 @@
 import { initializeApp, getApps, FirebaseApp } from "firebase/app";
 import { getAuth, Auth } from "firebase/auth";
 import { getFirestore, Firestore } from "firebase/firestore";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
-const firebaseConfig = {
-  apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-  authDomain: "leiria-1cfc9.firebaseapp.com",
-  databaseURL:
-    "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-  projectId: "leiria-1cfc9",
-  storageBucket: "leiria-1cfc9.firebasestorage.app",
-  messagingSenderId: "632599887141",
-  appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-  measurementId: "G-Q2QWQVH60L",
-};
+const firebaseConfig = getFirebaseConfig();
 
 // Simple singleton pattern without complex async initialization
 let firebaseApp: FirebaseApp | null = null;

--- a/src/firebase/ultraSafeConfig.ts
+++ b/src/firebase/ultraSafeConfig.ts
@@ -4,19 +4,10 @@
  */
 
 import { initializeApp, getApps, FirebaseApp } from "firebase/app";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
-// Firebase configuration
-const firebaseConfig = {
-  apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-  authDomain: "leiria-1cfc9.firebaseapp.com",
-  databaseURL:
-    "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-  projectId: "leiria-1cfc9",
-  storageBucket: "leiria-1cfc9.firebasestorage.app",
-  messagingSenderId: "632599887141",
-  appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-  measurementId: "G-Q2QWQVH60L",
-};
+// Firebase configuration using environment variables
+const firebaseConfig = getFirebaseConfig();
 
 export class UltraSafeFirebase {
   private static app: FirebaseApp | null = null;

--- a/src/firebase/unifiedSafeFirebase.ts
+++ b/src/firebase/unifiedSafeFirebase.ts
@@ -4,18 +4,9 @@
  */
 
 import { initializeApp, getApps, FirebaseApp } from "firebase/app";
+import { getFirebaseConfig } from "../config/firebaseEnv";
 
-const firebaseConfig = {
-  apiKey: "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw",
-  authDomain: "leiria-1cfc9.firebaseapp.com",
-  databaseURL:
-    "https://leiria-1cfc9-default-rtdb.europe-west1.firebasedatabase.app",
-  projectId: "leiria-1cfc9",
-  storageBucket: "leiria-1cfc9.firebasestorage.app",
-  messagingSenderId: "632599887141",
-  appId: "1:632599887141:web:1290b471d41fc3ad64eecc",
-  measurementId: "G-Q2QWQVH60L",
-};
+const firebaseConfig = getFirebaseConfig();
 
 export class UnifiedSafeFirebase {
   private static app: FirebaseApp | null = null;

--- a/src/hooks/useAutoUserMigration.ts
+++ b/src/hooks/useAutoUserMigration.ts
@@ -110,9 +110,6 @@ export const useAutoUserMigration = () => {
 
         // Try local migration as fallback
         try {
-          const { LocalUserMigration } = await import(
-            "../utils/localUserMigration"
-          );
           const localResult = await LocalUserMigration.migrateLocalUsers();
 
           if (localResult.success) {

--- a/src/hooks/useAutoUserMigration.ts
+++ b/src/hooks/useAutoUserMigration.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from "react";
+import { LocalUserMigration } from "../utils/localUserMigration";
 
 interface MigrationStatus {
   isRunning: boolean;

--- a/src/hooks/useAutoUserMigrationFixed.ts
+++ b/src/hooks/useAutoUserMigrationFixed.ts
@@ -111,9 +111,6 @@ export const useAutoUserMigrationFixed = () => {
 
         // Try local migration as fallback
         try {
-          const { LocalUserMigration } = await import(
-            "../utils/localUserMigration"
-          );
           const localResult = await LocalUserMigration.migrateLocalUsers();
 
           if (localResult.success) {

--- a/src/hooks/useAutoUserMigrationFixed.ts
+++ b/src/hooks/useAutoUserMigrationFixed.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useCallback } from "react";
+import { LocalUserMigration } from "../utils/localUserMigration";
 
 interface MigrationStatus {
   isRunning: boolean;

--- a/src/utils/emergencyConnectivityFix.ts
+++ b/src/utils/emergencyConnectivityFix.ts
@@ -145,16 +145,9 @@ export class EmergencyConnectivityFix {
       // Aguardar um pouco
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      // Reinicializar com configuração limpa
-      const firebaseConfig = {
-        apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-        authDomain: "leirisonda-16f8b.firebaseapp.com",
-        projectId: "leirisonda-16f8b",
-        storageBucket: "leirisonda-16f8b.firebasestorage.app",
-        messagingSenderId: "540456875574",
-        appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-        measurementId: "G-R9W43EHH2C",
-      };
+      // Reinicializar com configuração usando environment variables
+      const { getLegacyFirebaseConfig } = await import("../config/firebaseEnv");
+      const firebaseConfig = getLegacyFirebaseConfig();
 
       const newApp = initializeApp(firebaseConfig, "emergency-app");
       console.log("✅ Firebase app emergencial criada:", newApp.name);

--- a/src/utils/firebaseCompleteDiagnosis.ts
+++ b/src/utils/firebaseCompleteDiagnosis.ts
@@ -45,14 +45,8 @@ export async function runFirebaseCompleteDiagnosis() {
 
     // 3. Validação da configuração
     console.log("\n3️⃣ Validando configuração Firebase...");
-    const config = {
-      apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-      authDomain: "leirisonda-16f8b.firebaseapp.com",
-      projectId: "leirisonda-16f8b",
-      storageBucket: "leirisonda-16f8b.firebasestorage.app",
-      messagingSenderId: "540456875574",
-      appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-    };
+    const { getLegacyFirebaseConfig } = await import("../config/firebaseEnv");
+    const config = getLegacyFirebaseConfig();
 
     if (config.apiKey && config.projectId && config.authDomain) {
       results.configValid = true;

--- a/src/utils/firebaseDiagnostic.ts
+++ b/src/utils/firebaseDiagnostic.ts
@@ -9,16 +9,9 @@ import { getAuth } from "firebase/auth";
 
 // Import the main Firebase config instead of duplicating it
 import { getDB, getAuthService, waitForFirebaseInit } from "../firebase/config";
+import { getLegacyFirebaseConfig } from "../config/firebaseEnv";
 
-const firebaseConfig = {
-  apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-  authDomain: "leirisonda-16f8b.firebaseapp.com",
-  projectId: "leirisonda-16f8b",
-  storageBucket: "leirisonda-16f8b.firebasestorage.app",
-  messagingSenderId: "540456875574",
-  appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-  measurementId: "G-R9W43EHH2C",
-};
+const firebaseConfig = getLegacyFirebaseConfig();
 
 export class FirebaseDiagnostic {
   static async runFullDiagnostic() {

--- a/src/utils/firebaseForceInit.ts
+++ b/src/utils/firebaseForceInit.ts
@@ -5,17 +5,10 @@
 import { initializeApp, getApps, deleteApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { getLegacyFirebaseConfig } from "../config/firebaseEnv";
 
-// Configuração Firebase VERIFICADA E FUNCIONAL
-const FIREBASE_CONFIG = {
-  apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
-  authDomain: "leirisonda-16f8b.firebaseapp.com",
-  projectId: "leirisonda-16f8b",
-  storageBucket: "leirisonda-16f8b.firebasestorage.app",
-  messagingSenderId: "540456875574",
-  appId: "1:540456875574:web:8a8fd4870cb4c943a40a97",
-  measurementId: "G-R9W43EHH2C",
-};
+// Configuração Firebase usando environment variables
+const FIREBASE_CONFIG = getLegacyFirebaseConfig();
 
 // Variables globais para Firebase
 let globalApp: any = null;


### PR DESCRIPTION
Replace hardcoded Firebase API keys and configuration values with environment variables across multiple files.

Changes made:
- Redacted Firebase API keys, messaging sender IDs, app IDs, and measurement IDs in configuration files
- Updated documentation to use placeholder values instead of actual credentials
- Modified all Firebase configuration imports to use environment variable functions
- Replaced hardcoded config objects with calls to getFirebaseConfig() and getLegacyFirebaseConfig()
- Updated 15+ TypeScript files to import configuration from centralized environment module

Files affected:
- Configuration files: 090725leirisonda0710-RESTORE.md, 090725leirisonda0710.json
- Documentation: NETLIFY_SETUP.md
- Components: AdvancedSettings.tsx, FirebaseConfig.tsx
- Firebase modules: All config files in src/firebase/ directory
- Utility files: Emergency connectivity and diagnostic utilities

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 96`

🔗 [Edit in Builder.io](https://builder.io/app/projects/704dab3aebd64093bc4b7ec9180229be/swoosh-field)

👀 [Preview Link](https://704dab3aebd64093bc4b7ec9180229be-swoosh-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>704dab3aebd64093bc4b7ec9180229be</projectId>-->
<!--<branchName>swoosh-field</branchName>-->