### PR TITLE
Add TypeScript fixes and role type corrections

### DIFF
--- a/app-patch.txt
+++ b/app-patch.txt
@@ -1,0 +1,3 @@
+Linha 1867: Trocar "return;" por "return result;"
+
+A função handleLoginWithRememberMe deve retornar o resultado do login em vez de void.

--- a/fix-app.sh
+++ b/fix-app.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Correção do App.tsx para resolver erros TypeScript
+
+# Substituir "return;" por "return result;" na função handleLoginWithRememberMe
+sed 's/        return;/        return result;/' src/App.tsx > src/App.tsx.tmp && mv src/App.tsx.tmp src/App.tsx
+
+echo "Correção aplicada ao App.tsx"

--- a/fix-role-types.js
+++ b/fix-role-types.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+
+const filesToFix = [
+  "src/services/firebaseOnlyAuth.ts",
+  "src/services/simpleAuthService.ts",
+  "src/utils/userSyncManager.ts",
+  "src/utils/localUserMigration.ts",
+  "src/utils/migrateUsersToFirestore.ts",
+  "src/config/authorizedUsers.ts",
+];
+
+const fixes = [
+  {
+    pattern: /role: "super_admin" \| "manager" \| "technician"/g,
+    replacement: 'role: "super_admin" | "admin" | "manager" | "technician"',
+  },
+  {
+    pattern: /role: "user" \| "admin" \| "super_admin"/g,
+    replacement: 'role: "super_admin" | "admin" | "manager" | "technician"',
+  },
+];
+
+console.log("Corrigindo tipos de role...");
+
+filesToFix.forEach((filePath) => {
+  try {
+    if (fs.existsSync(filePath)) {
+      let content = fs.readFileSync(filePath, "utf8");
+      let modified = false;
+
+      fixes.forEach((fix) => {
+        if (fix.pattern.test(content)) {
+          content = content.replace(fix.pattern, fix.replacement);
+          modified = true;
+        }
+      });
+
+      if (modified) {
+        fs.writeFileSync(filePath, content);
+        console.log(`✅ ${filePath} corrigido`);
+      } else {
+        console.log(`⚪ ${filePath} não precisava de correção`);
+      }
+    } else {
+      console.log(`⚠️ ${filePath} não encontrado`);
+    }
+  } catch (error) {
+    console.error(`❌ Erro ao corrigir ${filePath}:`, error.message);
+  }
+});
+
+console.log("Correção de tipos concluída!");

--- a/fix-typescript.js
+++ b/fix-typescript.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+
+// Ler o arquivo App.tsx
+const filePath = "/src/App.tsx";
+let content = fs.readFileSync(filePath, "utf8");
+
+// Substituir o return vazio por return result na linha apropriada
+content = content.replace(
+  /(\s+)return;(\s+\/\/ Fallback|)/,
+  "$1return result;$2",
+);
+
+// Escrever o arquivo corrigido
+fs.writeFileSync(filePath, content);
+
+console.log("Correção aplicada ao App.tsx");


### PR DESCRIPTION
This pull request adds several utility scripts and documentation to fix TypeScript errors:

- Added app-patch.txt documenting the need to change "return;" to "return result;" in handleLoginWithRememberMe function
- Added fix-app.sh bash script to apply the return statement fix to App.tsx using sed
- Added fix-role-types.js Node.js script to standardize role types across multiple service files, replacing inconsistent role type definitions with "super_admin" | "admin" | "manager" | "technician"
- Added fix-typescript.js Node.js script to fix the return statement in App.tsx by replacing empty return with "return result;"

The scripts target files in src/services/, src/utils/, and src/config/ directories to ensure consistent TypeScript typing throughout the application.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 98`

🔗 [Edit in Builder.io](https://builder.io/app/projects/704dab3aebd64093bc4b7ec9180229be/mystic-haven)

👀 [Preview Link](https://704dab3aebd64093bc4b7ec9180229be-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>704dab3aebd64093bc4b7ec9180229be</projectId>-->
<!--<branchName>mystic-haven</branchName>-->