### PR TITLE
Add NETLIFY_NEXT_PLUGIN_SKIP environment variable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Adds NETLIFY_NEXT_PLUGIN_SKIP environment variable set to "true" in the build configuration.

This change modifies the netlify.toml file to include the new environment variable in the build.environment section.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 115`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c9f004729d6c4a36bebe49aac8cb5430/vibe-oasis)

👀 [Preview Link](https://c9f004729d6c4a36bebe49aac8cb5430-vibe-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c9f004729d6c4a36bebe49aac8cb5430</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->