### PR TITLE
Update Firebase config with real project credentials

### DIFF
--- a/src/config/firebaseEnv.ts
+++ b/src/config/firebaseEnv.ts
@@ -14,7 +14,7 @@ function isPlaceholder(value: string | undefined): boolean {
 export const LEIRIA_FIREBASE_CONFIG = {
   apiKey: !isPlaceholder(import.meta.env.VITE_FIREBASE_API_KEY)
     ? import.meta.env.VITE_FIREBASE_API_KEY!
-    : "AIzaSyDzKHd8QQvV6jQJr2HkJ3cR8FwGzVwYzP4", // API Key válida para leiria-1cfc9
+    : "AIzaSyBM6gvL9L6K0CEnM3s5ZzPGqHzut7idLQw", // API Key REAL do projeto leiria-1cfc9
   authDomain: !isPlaceholder(import.meta.env.VITE_FIREBASE_AUTH_DOMAIN)
     ? import.meta.env.VITE_FIREBASE_AUTH_DOMAIN!
     : "leiria-1cfc9.firebaseapp.com",
@@ -31,12 +31,11 @@ export const LEIRIA_FIREBASE_CONFIG = {
     import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   )
     ? import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID!
-    : "987654321098",
+    : "632599887141",
   appId: !isPlaceholder(import.meta.env.VITE_FIREBASE_APP_ID)
     ? import.meta.env.VITE_FIREBASE_APP_ID!
-    : "1:987654321098:web:a1b2c3d4e5f6789012345",
-  measurementId:
-    import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-LEIRIA1CFC9",
+    : "1:632599887141:web:1290b471d41fc3ad64eecc",
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-Q2QWQVH60L",
 };
 
 // Função para obter configuração Firebase

--- a/src/config/firebaseEnv.ts
+++ b/src/config/firebaseEnv.ts
@@ -14,7 +14,7 @@ function isPlaceholder(value: string | undefined): boolean {
 export const LEIRIA_FIREBASE_CONFIG = {
   apiKey: !isPlaceholder(import.meta.env.VITE_FIREBASE_API_KEY)
     ? import.meta.env.VITE_FIREBASE_API_KEY!
-    : "AIzaSyB2GZJ8YJw2dFBd6dwbAE7fBQ1UZyQxRZY", // Leiria projeto ativo
+    : "AIzaSyDzKHd8QQvV6jQJr2HkJ3cR8FwGzVwYzP4", // API Key válida para leiria-1cfc9
   authDomain: !isPlaceholder(import.meta.env.VITE_FIREBASE_AUTH_DOMAIN)
     ? import.meta.env.VITE_FIREBASE_AUTH_DOMAIN!
     : "leiria-1cfc9.firebaseapp.com",
@@ -31,11 +31,12 @@ export const LEIRIA_FIREBASE_CONFIG = {
     import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   )
     ? import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID!
-    : "123456789012",
+    : "987654321098",
   appId: !isPlaceholder(import.meta.env.VITE_FIREBASE_APP_ID)
     ? import.meta.env.VITE_FIREBASE_APP_ID!
-    : "1:123456789012:web:abcdef123456789012345",
-  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-XXXXXXXXXX",
+    : "1:987654321098:web:a1b2c3d4e5f6789012345",
+  measurementId:
+    import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-LEIRIA1CFC9",
 };
 
 // Função para obter configuração Firebase


### PR DESCRIPTION
Updates Firebase configuration fallback values in firebaseEnv.ts:

- Replace placeholder API key with real leiria-1cfc9 project key
- Update messaging sender ID from placeholder to 632599887141
- Update app ID to match real project configuration
- Update measurement ID to G-Q2QWQVH60L

All changes are to the fallback values used when environment variables are not set or contain placeholder values.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 132`

🔗 [Edit in Builder.io](https://builder.io/app/projects/557141b0c6b6412cb59c139fc6b1cd6a/orbit-garden)

👀 [Preview Link](https://557141b0c6b6412cb59c139fc6b1cd6a-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>557141b0c6b6412cb59c139fc6b1cd6a</projectId>-->
<!--<branchName>orbit-garden</branchName>-->