### PR TITLE
Remove app fallback logic and force main app usage

### DIFF
--- a/src/AppWithFallback.tsx
+++ b/src/AppWithFallback.tsx
@@ -19,11 +19,16 @@ const AppWithFallback: React.FC = () => {
     const forceSimple = localStorage.getItem("forceSimpleApp");
     const lastError = localStorage.getItem("lastAppError");
 
+    // TEMPORARIAMENTE: Always try main app first (remove flag)
     if (forceSimple === "true") {
-      console.log("📱 Forçando uso da app simples conforme preferência");
-      setUseSimpleApp(true);
-    } else if (lastError && retryCount === 0) {
-      console.log("⚠️ Erro anterior detectado, tentando app principal uma vez");
+      console.log("🔄 Removendo flag forceSimpleApp para tentar app principal");
+      localStorage.removeItem("forceSimpleApp");
+    }
+
+    if (lastError && retryCount === 0) {
+      console.log(
+        "⚠️ Erro anterior detectado, removendo e tentando app principal",
+      );
       localStorage.removeItem("lastAppError");
     }
   }, [retryCount]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,9 @@ console.log("🚀 Inicializando aplicação...");
 // Production safety - prevent crashes
 import "./utils/productionSafety";
 
+// Clear any flags that might force simple app
+import "./utils/clearAppFlags";
+
 // Adicionar error boundary e tratamento global de erros
 window.addEventListener("error", (event) => {
   console.error("❌ Global error:", event.error);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -79,11 +79,11 @@ try {
   console.log("🔍 Environment:", import.meta.env.MODE, import.meta.env.PROD);
   console.log("🔍 Base URL:", import.meta.env.BASE_URL);
 
-  // Use AppWithFallback in both production and development
-  const AppComponent = AppWithFallback;
+  // Use the main App directly
+  const AppComponent = App;
   console.log(
     "📱 Using app:",
-    "AppWithFallback (with fallback to AppSimple if needed)",
+    "App (main application with full functionality)",
   );
 
   ReactDOM.createRoot(rootElement).render(

--- a/src/utils/clearAppFlags.ts
+++ b/src/utils/clearAppFlags.ts
@@ -1,0 +1,17 @@
+// Clear any flags that might force the simple app
+export const clearAppFlags = () => {
+  console.log("🧹 Limpando flags da aplicação...");
+
+  // Clear force simple app flag
+  localStorage.removeItem("forceSimpleApp");
+  localStorage.removeItem("lastAppError");
+
+  // Clear any other problematic flags
+  localStorage.removeItem("appError");
+  localStorage.removeItem("useSimpleApp");
+
+  console.log("✅ Flags da aplicação limpas");
+};
+
+// Auto-clear on import
+clearAppFlags();


### PR DESCRIPTION
This change removes the fallback mechanism that would switch to a simple app version and forces the use of the main application.

Changes made:
- Modified AppWithFallback.tsx to clear forceSimpleApp flag instead of respecting it
- Updated main.tsx to use App component directly instead of AppWithFallback
- Added new clearAppFlags.ts utility that removes localStorage flags on import
- The clearAppFlags utility clears forceSimpleApp, lastAppError, appError, and useSimpleApp flags
- Updated console logging to reflect the new behavior

The application now always attempts to use the main App component with full functionality rather than falling back to a simpler version.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 162`

🔗 [Edit in Builder.io](https://builder.io/app/projects/557141b0c6b6412cb59c139fc6b1cd6a/echo-zone)

👀 [Preview Link](https://557141b0c6b6412cb59c139fc6b1cd6a-echo-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>557141b0c6b6412cb59c139fc6b1cd6a</projectId>-->
<!--<branchName>echo-zone</branchName>-->