### PR TITLE
Refactor Firebase initialization to trigger after login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1633,7 +1633,7 @@ function App() {
       }
     };
 
-    // Adicionar listeners para todas as coleç������es
+    // Adicionar listeners para todas as coleç��������es
     const collections = [
       "obras",
       "piscinas",
@@ -2077,6 +2077,9 @@ function App() {
         setIsAuthenticated(true);
         safeLocalStorage.setItem("currentUser", JSON.stringify(result.user));
         safeLocalStorage.setItem("isAuthenticated", "true");
+
+        // Inicializar Firebase Mobile APÓS login bem-sucedido
+        initMobileFirebaseAfterLogin();
 
         // Clear login form
         setLoginForm({ email: "", password: "" });


### PR DESCRIPTION
Changes Firebase Mobile initialization logic to occur after successful user login instead of after login page load.

Key changes:
- Removed loginPageLoaded state and related useEffect hooks
- Created initMobileFirebaseAfterLogin function to handle Firebase initialization
- Added calls to initMobileFirebaseAfterLogin in both login success handlers
- Simplified app ready state to always be true for immediate login display
- Removed timer-based login page loading detection

The Firebase Mobile service now initializes only when a user successfully authenticates, rather than when the login page loads.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/557141b0c6b6412cb59c139fc6b1cd6a/swoosh-lab)

👀 [Preview Link](https://557141b0c6b6412cb59c139fc6b1cd6a-swoosh-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>557141b0c6b6412cb59c139fc6b1cd6a</projectId>-->
<!--<branchName>swoosh-lab</branchName>-->